### PR TITLE
Fix inittest_simplewrap_c inittest_matrices_c symbol missing

### DIFF
--- a/simplewrap/tests/test_matrices_c.c
+++ b/simplewrap/tests/test_matrices_c.c
@@ -83,5 +83,12 @@ extern int swrap_list_functions(char *functions)
     return SUCCESS;
 }
 
+/*
+Dummy Function
+*/
+extern void inittest_matrices_c() {
+    return;
+}
+
 
 

--- a/simplewrap/tests/test_simplewrap_c.c
+++ b/simplewrap/tests/test_simplewrap_c.c
@@ -30,4 +30,10 @@ extern int callback_test(ptrFunc callback, int *out)
     return return_value;
 }
 
+/*
+Dummy Function
+*/
+extern void inittest_simplewrap_c() {
+    return;
+}
 


### PR DESCRIPTION
Temporary fix for #1 only.